### PR TITLE
[PKG-4396] 0.0.57 ❄️ 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+upload_channels:
+  - sfe1ed40
+channels:
+  - https://staging.continuum.io/prefect/fs/langchain-feedstock/pr4/2abfce0

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,2 @@
 upload_channels:
   - sfe1ed40
-channels:
-  - https://staging.continuum.io/prefect/fs/langchain-feedstock/pr4/2abfce0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,16 +10,16 @@ source:
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  skip: True  # [py<38]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
-    - python >=3.8
+    - python
     - poetry-core >=1.0.0
     - pip
   run:
-    - python >=3.8
+    - python
     - langchain >=0.1.15,<0.2.0
     - langchain-core >=0.1.41,<0.2.0
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,8 +34,12 @@ test:
 about:
   home: https://github.com/langchain-ai/langchain/tree/master/libs/experimental
   license: MIT
+  license_family: MIT
   license_file: LICENSE
   summary: This package holds experimental LangChain code, intended for research and experimental uses.
+  description: This package holds experimental LangChain code, intended for research and experimental uses.
+  dev_url: https://github.com/hwchase17/langchain
+  doc_url: https://python.langchain.com/
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
langchain-experimental 0.0.57 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-4396]
- [Upstream repository](https://github.com/langchain-ai/langchain/tree/v0.1.15/libs/experimental)
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/langchain-feedstock/pull/4
  - https://github.com/AnacondaRecipes/langchain-community-feedstock/pull/1
  - https://github.com/AnacondaRecipes/langchain-text-splitters-feedstock/pull/1
  - https://github.com/AnacondaRecipes/langchain-core-feedstock/pull/2
  - https://github.com/AnacondaRecipes/langsmith-feedstock/pull/3

### Explanation of changes:

- Upstream tests aren't present in pypi source, and there's no tagged release for `langchain-experimental` on github.
- Currently using staging channel for `langchain`.


[PKG-4396]: https://anaconda.atlassian.net/browse/PKG-4396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ